### PR TITLE
feat: make destAddress configurable via command line argument in eth-deposit-to-different-address

### DIFF
--- a/packages/eth-deposit-to-different-address/README.md
+++ b/packages/eth-deposit-to-different-address/README.md
@@ -28,8 +28,21 @@ Note that you can also set the environment variables in an `.env` file in the ro
 
 ## Run
 
+The script accepts two optional command line arguments:
+- `destination_address`: The address on the child chain where the ETH will be sent to (required)
+- `amount_in_eth`: The amount of ETH to deposit (optional, defaults to 0.0001 ETH)
+
+```bash
+# Basic usage with default amount (0.0001 ETH)
+yarn run exec <destination_address>
+
+# Specify custom amount (e.g., 0.001 ETH)
+yarn run exec <destination_address> 0.001
 ```
-yarn run exec
+
+Example:
+```bash
+yarn run exec 0x2D98cBc6f944c4bD36EdfE9f98cd7CB57faEC8d6 0.001
 ```
 
 <p align="center"><img src="../../assets/offchain_labs_logo.png" width="600"></p>

--- a/packages/eth-deposit-to-different-address/scripts/exec.js
+++ b/packages/eth-deposit-to-different-address/scripts/exec.js
@@ -19,10 +19,29 @@ const childChainProvider = new providers.JsonRpcProvider(process.env.CHAIN_RPC);
 const parentChainWallet = new Wallet(walletPrivateKey, parentChainProvider);
 
 /**
- * Set the destination address and amount to be deposited in the child chain (in wei)
+ * Get destination address from command line arguments
+ * Usage: node exec.js <destination_address> [amount_in_eth]
  */
-const destAddress = '0x2D98cBc6f944c4bD36EdfE9f98cd7CB57faEC8d6';
-const depositAmount = utils.parseEther('0.0001');
+const destAddress = process.argv[2];
+if (!destAddress) {
+  console.error('Error: Please provide a destination address as the first argument');
+  console.error('Usage: node exec.js <destination_address> [amount_in_eth]');
+  process.exit(1);
+}
+
+// Validate the address format
+if (!utils.isAddress(destAddress)) {
+  console.error('Error: Invalid destination address format');
+  process.exit(1);
+}
+
+/**
+ * Set the amount to be deposited in the child chain (in wei)
+ * Default to 0.0001 ETH if not specified
+ */
+const depositAmount = process.argv[3] 
+  ? utils.parseEther(process.argv[3])
+  : utils.parseEther('0.0001');
 
 const main = async () => {
   await arbLog('Deposit native token (e.g. Ether) via Arbitrum SDK to a different address');


### PR DESCRIPTION
## Description
This PR makes the destination address in the eth-deposit-to-different-address tutorial configurable via command line arguments, instead of being hardcoded in the script. This change improves the flexibility and usability of the tutorial.

## Changes
- Modified `exec.js` to accept destination address as a required command line argument
- Added optional command line argument for deposit amount (defaults to 0.0001 ETH)
- Added input validation for the destination address
- Updated README.md with new usage instructions and examples

## Usage Example
```bash
# Basic usage with default amount (0.0001 ETH)
yarn run exec <destination_address>

# With custom amount
yarn run exec <destination_address> 0.001
```

## Related Issue
Fixes {issue_id}